### PR TITLE
クエリパラメータで渡ってきた流入情報を保存する

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -1,3 +1,0 @@
-import { InflowSource } from "../dist/src/inflow-source.js"
-
-(new InflowSource()).set()

--- a/src/date.ts
+++ b/src/date.ts
@@ -11,7 +11,7 @@ export default function useDate() {
   const format = (value: string, format: string = 'YYYY/MM/DD'): string => {
     return dayjs(value).format(format)
   }
-  const create = (date: string | Date | CustomDate): CustomDate => {
+  const create = (date: number | string | Date | CustomDate): CustomDate => {
     return dayjs(date)
   }
 

--- a/test/date.spec.ts
+++ b/test/date.spec.ts
@@ -9,4 +9,10 @@ describe('~/date', () => {
       useDate().format('2020-01-21T14:29:58+09:00', 'YYYY年MM月DD日')
     ).toBe('2020年01月21日')
   })
+  describe('create', () => {
+    test('timestamp (milliseconds)', () => {
+      const date = useDate().create(1449414000000)
+      expect(date.toString()).toBe('Sun, 06 Dec 2015 15:00:00 GMT')
+    })
+  })
 })

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -438,4 +438,39 @@ describe('~/index', () => {
 
         expect(storage.getItem('last_page_url')).toBeNull()
     })
+
+    test('save intra site data', () => {
+        const urlSearchParams = new URLSearchParams({
+            last_visited_at: '1656342000000', // 2022-06-28 00:00:00.000
+            referer: 'https%3A%2F%2Ftwitter.com%2Ffoo%2Fbar',
+            landing_page_url: 'https%3A%2F%2Flp.macloud.jp%2F',
+            utm_source: 'newsletter1',
+            utm_medium: 'email',
+            utm_campaign: 'summer-sale',
+            utm_content: 'toplink',
+            gclid: 'Tester123',
+            // FYI: LP は単一ページなので landing_page_url と同じ URL が入る想定だが、
+            //      入力値を区別するために便宜上異なる URL を使う
+            last_page_url: 'https%3A%2F%2Flp.macloud.jp%2Fbaz%2Fqux',
+            device: 'pc'
+        })
+
+        // 渡されたクエリパラメータでデータが更新されるのをテストしたいので、ランディング判定されない情報を引数に渡す
+        inflowSource.set(
+            useDate().create('2022-06-28 00:00:00'),
+            undefined,
+            new URL(`https://macloud.jp/signup/seller?${urlSearchParams.toString()}`)
+        )
+
+        expect(storage.getItem('last_visited_at')).toBe('2022-06-28 00:00:00')
+        expect(storage.getItem('referer')).toBe('https://twitter.com/foo/bar')
+        expect(storage.getItem('landing_page_url')).toBe('https://lp.macloud.jp/')
+        expect(storage.getItem('utm_source')).toBe('newsletter1')
+        expect(storage.getItem('utm_medium')).toBe('email')
+        expect(storage.getItem('utm_campaign')).toBe('summer-sale')
+        expect(storage.getItem('utm_content')).toBe('toplink')
+        expect(storage.getItem('gclid')).toBe('Tester123')
+        expect(storage.getItem('last_page_url')).toBe('https://lp.macloud.jp/baz/qux')
+        expect(storage.getItem('device')).toBe('pc')
+    })
 })


### PR DESCRIPTION
- [x] 以下のようなクエリパラメータ付きの URL でアクセスすると localStorage に流入情報が保存されること
    - 全てのパラメータを含むパターン: http://localhost?referer=https://google.co.jp/&last_visited_at=1656452994000&landing_page_url=https://www.lp.macloud.jp/yuki-y3q2gszr&utm_source=foo&utm_medium=bar&utm_campaign=baz&utm_content=qux&gclid=quux&last_page_url=https://www.lp.macloud.jp/yuki-y3q2gszr-tmp
    - 必須パラメータのみ含むパターン: http://localhost?last_visited_at=1656452994000&landing_page_url=https%3A%2F%2Fwww.lp.macloud.jp%2Fyuki-y3q2gszr&last_page_url=https%3A%2F%2Fwww.lp.macloud.jp%2Fyuki-y3q2gszr-tmp
