### PR TITLE
サブドメインを内部サイトとみなして referer に保存しないように変更

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import useDate, { CustomDate } from './date'
 import { useUserAgent } from './user-agent'
-import { useUrl } from '~/url'
+import { useUrl } from './url'
 
 export type InflowSourceParams = {
     referer: string | null,
@@ -19,7 +19,7 @@ export interface InboundLinkDmaiMap {
     [dmai: string]: { company_id: number }
 }
 
-export const useInflowSource = (storage: Storage, baseUrl: URL) => {
+export const useInflowSource = (storage: Storage, baseUrl: URL, domainsRegardedAsExternal?: string[]) => {
     const landingKey = 'landing'
 
     const getAllParams = (): InflowSourceParams => {
@@ -113,7 +113,7 @@ export const useInflowSource = (storage: Storage, baseUrl: URL) => {
         }
 
         if (isLanding(currentDate, referer, currentUrl)) {
-            if (typeof referer !== 'undefined' && ! useUrl().isOwnedDomain(baseUrl, referer)) {
+            if (typeof referer !== 'undefined' && ! useUrl().isOwnedDomain(baseUrl, referer, domainsRegardedAsExternal)) {
                 storage.setItem('referer', referer.origin + referer.pathname)
             }
 
@@ -178,7 +178,7 @@ export const useInflowSource = (storage: Storage, baseUrl: URL) => {
             return true
         }
 
-        if (typeof referer !== 'undefined' && ! useUrl().isOwnedDomain(baseUrl, referer)) {
+        if (typeof referer !== 'undefined' && ! useUrl().isOwnedDomain(baseUrl, referer, domainsRegardedAsExternal)) {
             return true
         }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import useDate, { CustomDate } from './date'
 import { useUserAgent } from './user-agent'
+import { useUrl } from '~/url'
 
 export type InflowSourceParams = {
     referer: string | null,
@@ -20,8 +21,6 @@ export interface InboundLinkDmaiMap {
 
 export const useInflowSource = (storage: Storage, baseUrl: URL) => {
     const landingKey = 'landing'
-
-    const canonicalBaseUrl = (): string => baseUrl.origin
 
     const getAllParams = (): InflowSourceParams => {
         return {
@@ -114,7 +113,7 @@ export const useInflowSource = (storage: Storage, baseUrl: URL) => {
         }
 
         if (isLanding(currentDate, referer, currentUrl)) {
-            if (typeof referer !== 'undefined' && referer.origin !== canonicalBaseUrl()) {
+            if (typeof referer !== 'undefined' && ! useUrl().isOwnedDomain(baseUrl, referer)) {
                 storage.setItem('referer', referer.origin + referer.pathname)
             }
 
@@ -179,7 +178,7 @@ export const useInflowSource = (storage: Storage, baseUrl: URL) => {
             return true
         }
 
-        if (typeof referer !== 'undefined' && referer.origin !== canonicalBaseUrl()) {
+        if (typeof referer !== 'undefined' && ! useUrl().isOwnedDomain(baseUrl, referer)) {
             return true
         }
 

--- a/src/url.ts
+++ b/src/url.ts
@@ -1,8 +1,22 @@
 export const useUrl = () => {
+    const shouldRegardAsExternalDomain = (target: URL, domainsRegardedAsExternal?: string[]): boolean => {
+        if (typeof domainsRegardedAsExternal === 'undefined') {
+            return false
+        }
+
+        return domainsRegardedAsExternal.some((domain) => {
+            return target.hostname === domain
+        })
+    }
+
     /**
      * 自サイトのドメインかどうかを判定する（サブドメイン含む）
      */
-    const isOwnedDomain = (baseUrl: URL, target: URL): boolean => {
+    const isOwnedDomain = (baseUrl: URL, target: URL, domainsRegardedAsExternal?: string[]): boolean => {
+        if (shouldRegardAsExternalDomain(target, domainsRegardedAsExternal)) {
+            return false
+        }
+
         // 正規表現で使われる文字種をエスケープ
         // cf. https://github.com/sindresorhus/escape-string-regexp
         const escapedOrigin = baseUrl.hostname.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')

--- a/src/url.ts
+++ b/src/url.ts
@@ -1,0 +1,15 @@
+export const useUrl = () => {
+    /**
+     * 自サイトのドメインかどうかを判定する（サブドメイン含む）
+     */
+    const isOwnedDomain = (baseUrl: URL, target: URL): boolean => {
+        // 正規表現で使われる文字種をエスケープ
+        // cf. https://github.com/sindresorhus/escape-string-regexp
+        const escapedOrigin = baseUrl.hostname.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')
+        return target.hostname.search(`^(.+\\.)?${escapedOrigin}$`) !== -1
+    }
+
+    return {
+        isOwnedDomain
+    }
+}

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -27,7 +27,8 @@ describe('~/index', () => {
     }
 
     const storage = localStorage() as Storage
-    const inflowSource = useInflowSource(storage, new URL('https://macloud.jp'))
+    const domainsRegardedAsExternal = ['external.macloud.jp']
+    const inflowSource = useInflowSource(storage, new URL('https://macloud.jp'), domainsRegardedAsExternal)
 
     beforeEach(() => {
         storage.clear()
@@ -83,6 +84,15 @@ describe('~/index', () => {
         )
 
         expect(storage.getItem('landing_page_url')).toBe('https://macloud.jp/offers')
+
+        // 30分経過していないが、 referer のドメインが domainsRegardedAsExternal に含まれるのでランディング判定
+        inflowSource.set(
+            useDate().create('2022-03-09 00:00:00'),
+            new URL('https://external.macloud.jp/foo/bar'),
+            new URL('https://macloud.jp/interviews')
+        )
+
+        expect(storage.getItem('landing_page_url')).toBe('https://macloud.jp/interviews')
 
         // 30分経過していないが、 referer が外部サイトなのでランディング判定
         inflowSource.set(

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -75,14 +75,14 @@ describe('~/index', () => {
             new URL('https://macloud.jp/offers')
         )
 
-        // 30分経過していないが、 referer がサブドメインなのでランディング判定
+        // referer がサブドメインの場合はランディング判定しない
         inflowSource.set(
             useDate().create('2022-03-09 00:00:00'),
             new URL('https://corp.macloud.jp/foo/bar'),
             new URL('https://macloud.jp/interviews')
         )
 
-        expect(storage.getItem('landing_page_url')).toBe('https://macloud.jp/interviews')
+        expect(storage.getItem('landing_page_url')).toBe('https://macloud.jp/offers')
 
         // 30分経過していないが、 referer が外部サイトなのでランディング判定
         inflowSource.set(

--- a/test/url.spec.ts
+++ b/test/url.spec.ts
@@ -2,18 +2,28 @@ import { useUrl } from '~/url'
 
 describe('~/url', () => {
     describe('isOwnedDomain', () => {
-        test('success', () => {
+        test('check domains', () => {
             const baseUrl = new URL('https://macloud.jp')
             expect(useUrl().isOwnedDomain(baseUrl, new URL('https://macloud.jp'))).toBeTruthy()
             expect(useUrl().isOwnedDomain(baseUrl, new URL('https://sub.macloud.jp'))).toBeTruthy()
             expect(useUrl().isOwnedDomain(baseUrl, new URL('https://sub.sub.sub.macloud.jp'))).toBeTruthy()
-        })
-
-        test('failure', () => {
-            const baseUrl = new URL('https://macloud.jp')
             expect(useUrl().isOwnedDomain(baseUrl, new URL('https://macloud.jpa'))).toBeFalsy()
             expect(useUrl().isOwnedDomain(baseUrl, new URL('https://macloud.jp.com'))).toBeFalsy()
             expect(useUrl().isOwnedDomain(baseUrl, new URL('https://amacloud.jp'))).toBeFalsy()
+        })
+
+        test('check domains when domainsRegardedAsExternal is set', () => {
+            const baseUrl = new URL('https://macloud.jp')
+            const domainsRegardedAsExternal = [
+                'foo.macloud.jp',
+                'bar.foo.macloud.jp'
+            ]
+            expect(useUrl().isOwnedDomain(baseUrl, new URL('https://macloud.jp'), domainsRegardedAsExternal)).toBeTruthy()
+            expect(useUrl().isOwnedDomain(baseUrl, new URL('https://sub.macloud.jp'), domainsRegardedAsExternal)).toBeTruthy()
+            expect(useUrl().isOwnedDomain(baseUrl, new URL('https://foo.macloud.jp'), domainsRegardedAsExternal)).toBeFalsy()
+            expect(useUrl().isOwnedDomain(baseUrl, new URL('https://sub.foo.macloud.jp'), domainsRegardedAsExternal)).toBeTruthy()
+            expect(useUrl().isOwnedDomain(baseUrl, new URL('https://bar.foo.macloud.jp'), domainsRegardedAsExternal)).toBeFalsy()
+            expect(useUrl().isOwnedDomain(baseUrl, new URL('https://baz.bar.foo.macloud.jp'), domainsRegardedAsExternal)).toBeTruthy()
         })
     })
 })

--- a/test/url.spec.ts
+++ b/test/url.spec.ts
@@ -1,0 +1,19 @@
+import { useUrl } from '~/url'
+
+describe('~/url', () => {
+    describe('isOwnedDomain', () => {
+        test('success', () => {
+            const baseUrl = new URL('https://macloud.jp')
+            expect(useUrl().isOwnedDomain(baseUrl, new URL('https://macloud.jp'))).toBeTruthy()
+            expect(useUrl().isOwnedDomain(baseUrl, new URL('https://sub.macloud.jp'))).toBeTruthy()
+            expect(useUrl().isOwnedDomain(baseUrl, new URL('https://sub.sub.sub.macloud.jp'))).toBeTruthy()
+        })
+
+        test('failure', () => {
+            const baseUrl = new URL('https://macloud.jp')
+            expect(useUrl().isOwnedDomain(baseUrl, new URL('https://macloud.jpa'))).toBeFalsy()
+            expect(useUrl().isOwnedDomain(baseUrl, new URL('https://macloud.jp.com'))).toBeFalsy()
+            expect(useUrl().isOwnedDomain(baseUrl, new URL('https://amacloud.jp'))).toBeFalsy()
+        })
+    })
+})


### PR DESCRIPTION
- [x] referer がサブドメインだった場合、 localStorage に保存されないこと
- [x] referer が `domainsRegardedAsExternal` で指定されたドメインだった場合、（サブドメインであっても） localStorage に保存されること